### PR TITLE
Добавляет экран создания турнира

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,13 +19,27 @@
   </header>
 
   <main>
-    <div class="cta-buttons">
-      <button class="btn" disabled>Новый турнир</button>
-      <button class="btn" disabled>Загрузить турнир</button>
-    </div>
-    <section class="intro">
+    <section id="start-screen" class="intro">
       <h2>Добро пожаловать!</h2>
+      <div class="cta-buttons">
+        <button id="new-tournament-btn" class="btn">Новый турнир</button>
+        <button id="load-tournament-btn" class="btn" disabled>Загрузить турнир</button>
+      </div>
       <p>Здесь будет описание приложения и его возможностей.</p>
+    </section>
+
+    <section id="new-tournament" class="hidden">
+      <h2>Новый турнир</h2>
+      <div class="toggle">
+        <label><input type="radio" name="playerType" value="names" checked> С именами</label>
+        <label><input type="radio" name="playerType" value="nonames"> Без имён</label>
+      </div>
+      <div id="counter" class="counter hidden">
+        <button id="decrease" class="btn small">-</button>
+        <span id="count">2</span>
+        <button id="increase" class="btn small">+</button>
+      </div>
+      <button id="back-btn" class="btn secondary">Назад</button>
     </section>
 
     <section class="placeholder">
@@ -36,5 +50,6 @@
   <footer>
     <p>&copy; 2024 Padel Brackets</p>
   </footer>
+<script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,68 @@
+const newBtn = document.getElementById('new-tournament-btn');
+const backBtn = document.getElementById('back-btn');
+const startScreen = document.getElementById('start-screen');
+const newScreen = document.getElementById('new-tournament');
+const typeRadios = document.querySelectorAll('input[name="playerType"]');
+const counter = document.getElementById('counter');
+const decreaseBtn = document.getElementById('decrease');
+const increaseBtn = document.getElementById('increase');
+const countSpan = document.getElementById('count');
+
+let count = 2;
+const MIN_PLAYERS = 2;
+const MAX_PLAYERS = 64;
+
+function showNewTournament() {
+  startScreen.classList.add('hidden');
+  newScreen.classList.remove('hidden');
+  document.querySelector('input[name="playerType"][value="names"]').checked = true;
+  counter.classList.add('hidden');
+  count = MIN_PLAYERS;
+  updateCounter();
+}
+
+function backToStart() {
+  newScreen.classList.add('hidden');
+  startScreen.classList.remove('hidden');
+}
+
+function updateCounter() {
+  countSpan.textContent = count;
+  decreaseBtn.disabled = count <= MIN_PLAYERS;
+  increaseBtn.disabled = count >= MAX_PLAYERS;
+}
+
+function handleTypeChange(e) {
+  if (e.target.value === 'nonames') {
+    counter.classList.remove('hidden');
+  } else {
+    counter.classList.add('hidden');
+  }
+}
+
+typeRadios.forEach(r => r.addEventListener('change', handleTypeChange));
+
+increaseBtn.addEventListener('click', () => {
+  if (count < MAX_PLAYERS) {
+    count++;
+    updateCounter();
+  }
+});
+
+decreaseBtn.addEventListener('click', () => {
+  if (count > MIN_PLAYERS) {
+    count--;
+    updateCounter();
+  }
+});
+
+newBtn.addEventListener('click', () => {
+  showNewTournament();
+});
+
+backBtn.addEventListener('click', () => {
+  backToStart();
+});
+
+updateCounter();
+

--- a/style.css
+++ b/style.css
@@ -72,3 +72,34 @@ footer {
   padding: 1rem;
   margin-top: 2rem;
 }
+.hidden {
+  display: none;
+}
+
+.counter {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.btn.small {
+  padding: 0.5rem 0.75rem;
+}
+
+.btn.secondary {
+  background-color: #e0e0e0;
+  color: #333;
+}
+
+#new-tournament {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.toggle {
+  display: flex;
+  gap: 1rem;
+}
+


### PR DESCRIPTION
## Summary
- move tournament buttons under greeting
- add page for new tournament
- allow choosing between named and unnamed players
- add interactive player counter
- style new controls and wire up JS
- reset counter when re-opening new tournament screen
- increase spacing between elements

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a6528db988328a7ce910f3c413ed9