### PR TITLE
Add tournament name input and dynamic heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,17 @@
       <p>Здесь будет описание приложения и его возможностей.</p>
     </section>
 
+    <section id="name-screen" class="hidden name-screen">
+      <h2>Название турнира</h2>
+      <input id="tournament-name-input" type="text" placeholder="Введите название" maxlength="50">
+      <div class="cta-buttons">
+        <button id="name-next-btn" class="btn" disabled>Далее</button>
+        <button id="name-back-btn" class="btn secondary">Назад</button>
+      </div>
+    </section>
+
     <section id="new-tournament" class="hidden">
-      <h2>Новый турнир</h2>
+      <h2 id="tournament-heading">Новый турнир</h2>
       <div class="toggle">
         <label><input type="radio" name="playerType" value="names" checked> С именами</label>
         <label><input type="radio" name="playerType" value="nonames"> Без имён</label>

--- a/script.js
+++ b/script.js
@@ -1,7 +1,13 @@
 const newBtn = document.getElementById('new-tournament-btn');
+const loadBtn = document.getElementById('load-tournament-btn');
 const backBtn = document.getElementById('back-btn');
 const startScreen = document.getElementById('start-screen');
+const nameScreen = document.getElementById('name-screen');
+const nameInput = document.getElementById('tournament-name-input');
+const nameNextBtn = document.getElementById('name-next-btn');
+const nameBackBtn = document.getElementById('name-back-btn');
 const newScreen = document.getElementById('new-tournament');
+const heading = document.getElementById('tournament-heading');
 const typeRadios = document.querySelectorAll('input[name="playerType"]');
 const counter = document.getElementById('counter');
 const decreaseBtn = document.getElementById('decrease');
@@ -11,13 +17,23 @@ const countSpan = document.getElementById('count');
 let count = 2;
 const MIN_PLAYERS = 2;
 const MAX_PLAYERS = 64;
+let tournamentName = '';
+
+function showNameScreen() {
+  startScreen.classList.add('hidden');
+  nameScreen.classList.remove('hidden');
+  nameInput.value = tournamentName;
+  validateName();
+}
 
 function showNewTournament() {
-  startScreen.classList.add('hidden');
+  nameScreen.classList.add('hidden');
   newScreen.classList.remove('hidden');
+  heading.textContent = tournamentName || 'Новый турнир';
 }
 
 function backToStart() {
+  nameScreen.classList.add('hidden');
   newScreen.classList.add('hidden');
   startScreen.classList.remove('hidden');
 }
@@ -26,6 +42,14 @@ function updateCounter() {
   countSpan.textContent = count;
   decreaseBtn.disabled = count <= MIN_PLAYERS;
   increaseBtn.disabled = count >= MAX_PLAYERS;
+}
+
+function validateName() {
+  const value = nameInput.value.trim();
+  const pattern = /^[A-Za-zА-Яа-я0-9- ]{3,50}$/u;
+  const valid = pattern.test(value);
+  nameNextBtn.disabled = !valid;
+  return valid;
 }
 
 function handleTypeChange(e) {
@@ -37,6 +61,7 @@ function handleTypeChange(e) {
 }
 
 typeRadios.forEach(r => r.addEventListener('change', handleTypeChange));
+nameInput.addEventListener('input', validateName);
 
 increaseBtn.addEventListener('click', () => {
   if (count < MAX_PLAYERS) {
@@ -53,11 +78,24 @@ decreaseBtn.addEventListener('click', () => {
 });
 
 newBtn.addEventListener('click', () => {
-  showNewTournament();
+  showNameScreen();
+});
+
+nameBackBtn.addEventListener('click', () => {
+  backToStart();
+});
+
+nameNextBtn.addEventListener('click', () => {
+  if (validateName()) {
+    tournamentName = nameInput.value.trim();
+    showNewTournament();
+  }
 });
 
 backBtn.addEventListener('click', () => {
-  backToStart();
+  newScreen.classList.add('hidden');
+  nameScreen.classList.remove('hidden');
+  validateName();
 });
 
 updateCounter();

--- a/style.css
+++ b/style.css
@@ -92,3 +92,20 @@ footer {
   color: #333;
 }
 
+/* Screen for entering tournament name */
+.name-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.name-screen input {
+  padding: 0.75rem;
+  font-size: 1rem;
+  width: 100%;
+  max-width: 320px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+}
+


### PR DESCRIPTION
## Summary
- introduce name screen with input and validation
- persist tournament name in session variable
- update heading to show selected name
- adjust navigation between screens

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_688a684f6d74832882645d08ad67f046