### PR TITLE
Add dynamic player name fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,8 @@
         <span id="count">2</span>
         <button id="increase" class="btn small">+</button>
       </div>
+      <div id="names-container" class="names hidden"></div>
+      <p id="limit-message" class="limit-message hidden"></p>
       <button id="back-btn" class="btn secondary">Назад</button>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -13,6 +13,11 @@ const counter = document.getElementById('counter');
 const decreaseBtn = document.getElementById('decrease');
 const increaseBtn = document.getElementById('increase');
 const countSpan = document.getElementById('count');
+const namesContainer = document.getElementById('names-container');
+const limitMessage = document.getElementById('limit-message');
+
+const MAX_NAMED_PLAYERS = 16;
+let players = [];
 
 let count = 2;
 const MIN_PLAYERS = 2;
@@ -30,6 +35,7 @@ function showNewTournament() {
   nameScreen.classList.add('hidden');
   newScreen.classList.remove('hidden');
   heading.textContent = tournamentName || 'Новый турнир';
+  handleTypeChange({target: document.querySelector('input[name="playerType"]:checked')});
 }
 
 function backToStart() {
@@ -44,6 +50,56 @@ function updateCounter() {
   increaseBtn.disabled = count >= MAX_PLAYERS;
 }
 
+function initPlayers() {
+  namesContainer.innerHTML = '';
+  players = [];
+  addPlayerRow();
+}
+
+function addPlayerRow() {
+  if (players.length >= MAX_NAMED_PLAYERS) return;
+
+  const existingAdd = namesContainer.querySelector('.add-player');
+  if (existingAdd) existingAdd.remove();
+
+  const number = players.length + 1;
+  const row = document.createElement('div');
+  row.className = 'player-row';
+
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.placeholder = `Игрок ${number}`;
+  input.maxLength = 30;
+  input.addEventListener('input', () => {
+    players[number - 1] = input.value.trim();
+  });
+  row.appendChild(input);
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.textContent = '+';
+  btn.className = 'btn small add-player';
+  btn.addEventListener('click', addPlayerRow);
+  row.appendChild(btn);
+
+  namesContainer.appendChild(row);
+  players.push('');
+
+  updateLimit();
+}
+
+function updateLimit() {
+  const addBtn = namesContainer.querySelector('.add-player');
+  if (players.length >= MAX_NAMED_PLAYERS) {
+    if (addBtn) addBtn.disabled = true;
+    limitMessage.textContent = 'Достигнуто максимальное количество игроков';
+    limitMessage.classList.remove('hidden');
+  } else {
+    if (addBtn) addBtn.disabled = false;
+    limitMessage.classList.add('hidden');
+  }
+}
+
 function validateName() {
   const value = nameInput.value.trim();
   const pattern = /^[A-Za-zА-Яа-я0-9- ]{3,50}$/u;
@@ -55,8 +111,13 @@ function validateName() {
 function handleTypeChange(e) {
   if (e.target.value === 'nonames') {
     counter.classList.remove('hidden');
+    namesContainer.classList.add('hidden');
+    limitMessage.classList.add('hidden');
   } else {
     counter.classList.add('hidden');
+    namesContainer.classList.remove('hidden');
+    if (players.length === 0) initPlayers();
+    updateLimit();
   }
 }
 
@@ -99,4 +160,5 @@ backBtn.addEventListener('click', () => {
 });
 
 updateCounter();
+handleTypeChange({target: document.querySelector('input[name="playerType"]:checked')});
 

--- a/style.css
+++ b/style.css
@@ -109,3 +109,31 @@ footer {
   border-radius: 8px;
 }
 
+/* Player names section */
+.names {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.player-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.player-row input {
+  flex: 1;
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+}
+
+.limit-message {
+  color: #d32f2f;
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+}
+


### PR DESCRIPTION
## Summary
- add player name fields when creating tournament
- style player name inputs
- handle adding up to 16 names with limit message

## Testing
- `node --check script.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688a69bbe9908328aabdc840de7bb03b