### PR TITLE
Split tournament setup into multiple pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,40 +21,11 @@
   <main>
     <section id="start-screen" class="intro">
       <h2>Добро пожаловать!</h2>
+      <p>Сообщество PADDLE Community помогает быстро организовать мини-турнир и поделиться результатами.</p>
       <div class="cta-buttons">
         <button id="new-tournament-btn" class="btn">Новый турнир</button>
         <button id="load-tournament-btn" class="btn" disabled>Загрузить турнир</button>
       </div>
-      <p>Здесь будет описание приложения и его возможностей.</p>
-    </section>
-
-    <section id="name-screen" class="hidden name-screen">
-      <h2>Название турнира</h2>
-      <input id="tournament-name-input" type="text" placeholder="Введите название" maxlength="50">
-      <div class="cta-buttons">
-        <button id="name-next-btn" class="btn" disabled>Далее</button>
-        <button id="name-back-btn" class="btn secondary">Назад</button>
-      </div>
-    </section>
-
-    <section id="new-tournament" class="hidden">
-      <h2 id="tournament-heading">Новый турнир</h2>
-      <div class="toggle">
-        <label><input type="radio" name="playerType" value="names" checked> С именами</label>
-        <label><input type="radio" name="playerType" value="nonames"> Без имён</label>
-      </div>
-      <div id="counter" class="counter hidden">
-        <button id="decrease" class="btn small">-</button>
-        <span id="count">2</span>
-        <button id="increase" class="btn small">+</button>
-      </div>
-      <div id="names-container" class="names hidden"></div>
-      <p id="limit-message" class="limit-message hidden"></p>
-      <button id="back-btn" class="btn secondary">Назад</button>
-    </section>
-
-    <section class="placeholder">
-      <p>Разделы приложения появятся здесь в процессе разработки.</p>
     </section>
   </main>
 

--- a/name.html
+++ b/name.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Padel Brackets — Название</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Padel Brackets</h1>
+  </header>
+
+  <main>
+    <section id="name-screen" class="name-screen">
+      <h2>Введите название турнира</h2>
+      <input id="tournament-name-input" type="text" placeholder="Название" maxlength="50">
+      <div class="cta-buttons">
+        <button id="name-next-btn" class="btn" disabled>Далее</button>
+        <button id="name-back-btn" class="btn secondary">Назад</button>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; 2024 Padel Brackets</p>
+  </footer>
+<script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,63 +1,33 @@
-const newBtn = document.getElementById('new-tournament-btn');
-const loadBtn = document.getElementById('load-tournament-btn');
-const backBtn = document.getElementById('back-btn');
-const startScreen = document.getElementById('start-screen');
-const nameScreen = document.getElementById('name-screen');
-const nameInput = document.getElementById('tournament-name-input');
-const nameNextBtn = document.getElementById('name-next-btn');
-const nameBackBtn = document.getElementById('name-back-btn');
-const newScreen = document.getElementById('new-tournament');
-const heading = document.getElementById('tournament-heading');
-const typeRadios = document.querySelectorAll('input[name="playerType"]');
-const counter = document.getElementById('counter');
-const decreaseBtn = document.getElementById('decrease');
-const increaseBtn = document.getElementById('increase');
-const countSpan = document.getElementById('count');
-const namesContainer = document.getElementById('names-container');
-const limitMessage = document.getElementById('limit-message');
-
 const MAX_NAMED_PLAYERS = 16;
-let players = [];
-
-let count = 2;
 const MIN_PLAYERS = 2;
 const MAX_PLAYERS = 64;
+
+let players = [];
+let count = 2;
 let tournamentName = '';
 
-function showNameScreen() {
-  startScreen.classList.add('hidden');
-  nameScreen.classList.remove('hidden');
-  nameInput.value = tournamentName;
-  validateName();
-}
-
-function showNewTournament() {
-  nameScreen.classList.add('hidden');
-  newScreen.classList.remove('hidden');
-  heading.textContent = tournamentName || 'Новый турнир';
-  handleTypeChange({target: document.querySelector('input[name="playerType"]:checked')});
-}
-
-function backToStart() {
-  nameScreen.classList.add('hidden');
-  newScreen.classList.add('hidden');
-  startScreen.classList.remove('hidden');
-}
-
 function updateCounter() {
+  const countSpan = document.getElementById('count');
+  const decreaseBtn = document.getElementById('decrease');
+  const increaseBtn = document.getElementById('increase');
+  if (!countSpan || !decreaseBtn || !increaseBtn) return;
   countSpan.textContent = count;
   decreaseBtn.disabled = count <= MIN_PLAYERS;
   increaseBtn.disabled = count >= MAX_PLAYERS;
 }
 
 function initPlayers() {
+  const namesContainer = document.getElementById('names-container');
+  if (!namesContainer) return;
   namesContainer.innerHTML = '';
   players = [];
   addPlayerRow();
 }
 
 function addPlayerRow() {
-  if (players.length >= MAX_NAMED_PLAYERS) return;
+  const namesContainer = document.getElementById('names-container');
+  const limitMessage = document.getElementById('limit-message');
+  if (!namesContainer || players.length >= MAX_NAMED_PLAYERS) return;
 
   const existingAdd = namesContainer.querySelector('.add-player');
   if (existingAdd) existingAdd.remove();
@@ -89,6 +59,9 @@ function addPlayerRow() {
 }
 
 function updateLimit() {
+  const namesContainer = document.getElementById('names-container');
+  const limitMessage = document.getElementById('limit-message');
+  if (!namesContainer || !limitMessage) return;
   const addBtn = namesContainer.querySelector('.add-player');
   if (players.length >= MAX_NAMED_PLAYERS) {
     if (addBtn) addBtn.disabled = true;
@@ -101,14 +74,21 @@ function updateLimit() {
 }
 
 function validateName() {
+  const nameInput = document.getElementById('tournament-name-input');
+  const nextBtn = document.getElementById('name-next-btn');
+  if (!nameInput) return false;
   const value = nameInput.value.trim();
   const pattern = /^[A-Za-zА-Яа-я0-9- ]{3,50}$/u;
   const valid = pattern.test(value);
-  nameNextBtn.disabled = !valid;
+  if (nextBtn) nextBtn.disabled = !valid;
   return valid;
 }
 
 function handleTypeChange(e) {
+  const counter = document.getElementById('counter');
+  const namesContainer = document.getElementById('names-container');
+  const limitMessage = document.getElementById('limit-message');
+  if (!counter || !namesContainer || !limitMessage) return;
   if (e.target.value === 'nonames') {
     counter.classList.remove('hidden');
     namesContainer.classList.add('hidden');
@@ -121,44 +101,76 @@ function handleTypeChange(e) {
   }
 }
 
-typeRadios.forEach(r => r.addEventListener('change', handleTypeChange));
-nameInput.addEventListener('input', validateName);
+document.addEventListener('DOMContentLoaded', () => {
+  const newBtn = document.getElementById('new-tournament-btn');
+  if (newBtn) {
+    newBtn.addEventListener('click', () => {
+      window.location.href = 'name.html';
+    });
+  }
 
-increaseBtn.addEventListener('click', () => {
-  if (count < MAX_PLAYERS) {
-    count++;
+  const nameInput = document.getElementById('tournament-name-input');
+  if (nameInput) {
+    nameInput.value = localStorage.getItem('tournamentName') || '';
+    validateName();
+    nameInput.addEventListener('input', validateName);
+
+    const nextBtn = document.getElementById('name-next-btn');
+    if (nextBtn) {
+      nextBtn.addEventListener('click', () => {
+        if (validateName()) {
+          localStorage.setItem('tournamentName', nameInput.value.trim());
+          window.location.href = 'type.html';
+        }
+      });
+    }
+
+    const backBtn = document.getElementById('name-back-btn');
+    if (backBtn) {
+      backBtn.addEventListener('click', () => {
+        window.location.href = 'index.html';
+      });
+    }
+  }
+
+  const heading = document.getElementById('tournament-heading');
+  if (heading) {
+    tournamentName = localStorage.getItem('tournamentName') || '';
+    heading.textContent = tournamentName || 'Новый турнир';
+
+    const typeRadios = document.querySelectorAll('input[name="playerType"]');
+    typeRadios.forEach(r => r.addEventListener('change', handleTypeChange));
+    if (typeRadios.length) {
+      handleTypeChange({ target: document.querySelector('input[name="playerType"]:checked') });
+    }
+
+    const decreaseBtn = document.getElementById('decrease');
+    const increaseBtn = document.getElementById('increase');
+
+    if (increaseBtn) {
+      increaseBtn.addEventListener('click', () => {
+        if (count < MAX_PLAYERS) {
+          count++;
+          updateCounter();
+        }
+      });
+    }
+    if (decreaseBtn) {
+      decreaseBtn.addEventListener('click', () => {
+        if (count > MIN_PLAYERS) {
+          count--;
+          updateCounter();
+        }
+      });
+    }
+
+    const backBtn = document.getElementById('back-btn');
+    if (backBtn) {
+      backBtn.addEventListener('click', () => {
+        window.location.href = 'name.html';
+      });
+    }
+
     updateCounter();
   }
 });
-
-decreaseBtn.addEventListener('click', () => {
-  if (count > MIN_PLAYERS) {
-    count--;
-    updateCounter();
-  }
-});
-
-newBtn.addEventListener('click', () => {
-  showNameScreen();
-});
-
-nameBackBtn.addEventListener('click', () => {
-  backToStart();
-});
-
-nameNextBtn.addEventListener('click', () => {
-  if (validateName()) {
-    tournamentName = nameInput.value.trim();
-    showNewTournament();
-  }
-});
-
-backBtn.addEventListener('click', () => {
-  newScreen.classList.add('hidden');
-  nameScreen.classList.remove('hidden');
-  validateName();
-});
-
-updateCounter();
-handleTypeChange({target: document.querySelector('input[name="playerType"]:checked')});
-

--- a/type.html
+++ b/type.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Padel Brackets — Тип турнира</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Padel Brackets</h1>
+  </header>
+
+  <main>
+    <section id="new-tournament">
+      <h2 id="tournament-heading">Новый турнир</h2>
+      <div class="toggle">
+        <label><input type="radio" name="playerType" value="names" checked> С именами</label>
+        <label><input type="radio" name="playerType" value="nonames"> Без имён</label>
+      </div>
+      <div id="counter" class="counter hidden">
+        <button id="decrease" class="btn small">-</button>
+        <span id="count">2</span>
+        <button id="increase" class="btn small">+</button>
+      </div>
+      <div id="names-container" class="names hidden"></div>
+      <p id="limit-message" class="limit-message hidden"></p>
+      <button id="back-btn" class="btn secondary">Назад</button>
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; 2024 Padel Brackets</p>
+  </footer>
+<script src="script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- move welcome, tournament name and type selection into individual HTML pages
- store tournament name in localStorage to keep it across pages
- adjust JavaScript to initialize only on the relevant page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a6b3ebbc0832881738e1647c80f47