### PR TITLE
Add validation on tournament creation

### DIFF
--- a/script.js
+++ b/script.js
@@ -187,6 +187,28 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
 
+    const createBtn = document.getElementById('create-btn');
+    if (createBtn) {
+      createBtn.addEventListener('click', () => {
+        const validationMsg = document.getElementById('validation-message');
+        let total = 0;
+        const type = document.querySelector('input[name="playerType"]:checked');
+        if (type && type.value === 'names') {
+          total = players.length;
+        } else {
+          total = count;
+        }
+        if (validationMsg) {
+          if (total % 4 !== 0) {
+            validationMsg.textContent = 'Количество игроков должно быть кратно 4';
+            validationMsg.classList.remove('hidden');
+          } else {
+            validationMsg.classList.add('hidden');
+          }
+        }
+      });
+    }
+
     updateCounter();
   }
 });

--- a/style.css
+++ b/style.css
@@ -48,7 +48,7 @@ section {
 .cta-buttons {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.5rem;
   margin-bottom: 2rem;
 }
 
@@ -80,7 +80,7 @@ footer {
   display: flex;
   align-items: center;
   gap: 1rem;
-  margin-top: 1rem;
+  margin: 1.5rem 0;
 }
 
 .btn.small {
@@ -90,6 +90,13 @@ footer {
 .btn.secondary {
   background-color: #e0e0e0;
   color: #333;
+}
+
+/* Toggle section on type screen */
+.toggle {
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
 }
 
 /* Screen for entering tournament name */
@@ -114,7 +121,7 @@ footer {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  margin-top: 1rem;
+  margin: 1rem 0 1.5rem;
 }
 
 .player-row {
@@ -132,6 +139,13 @@ footer {
 }
 
 .limit-message {
+  color: #d32f2f;
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+}
+
+/* Error message for validation */
+.validation-message {
   color: #d32f2f;
   font-size: 0.875rem;
   margin-top: 0.5rem;

--- a/type.html
+++ b/type.html
@@ -25,7 +25,11 @@
       </div>
       <div id="names-container" class="names hidden"></div>
       <p id="limit-message" class="limit-message hidden"></p>
-      <button id="back-btn" class="btn secondary">Назад</button>
+      <p id="validation-message" class="validation-message hidden"></p>
+      <div class="cta-buttons">
+        <button id="create-btn" class="btn">Создать турнир</button>
+        <button id="back-btn" class="btn secondary">Назад</button>
+      </div>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- adjust spacing on tournament type page
- add validation message and create button
- check player count when creating a tournament

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a702bafe48328979f5c17c200f90d